### PR TITLE
chore(update): solc 0.8.24

### DIFF
--- a/list-linux-amd64.json
+++ b/list-linux-amd64.json
@@ -947,9 +947,22 @@
         "bzzr://57ffacd9e36ddad5f6716914cb652c6ceffe72c5539b39a7ee88941d6fe939ee",
         "dweb:/ipfs/QmeC2pQS54j76BP85Akhsv1XEejqv2zxyK4mJvio7Pu9h4"
       ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.24+commit.e11b9ed9",
+      "version": "0.8.24",
+      "build": "commit.e11b9ed9",
+      "longVersion": "0.8.24+commit.e11b9ed9",
+      "keccak256": "0x5a127e73ef8c90f2df60ff2fe9dd79709da9e90d2d075cf05784c9a3efee2528",
+      "sha256": "0xfb03a29a517452b9f12bcf459ef37d0a543765bb3bbc911e70a87d6a37c30d5f",
+      "urls": [
+        "bzzr://696eac6b03201fe1e090f793ff3abcf862d738195e3db0da14c1cae1dc9315f6",
+        "dweb:/ipfs/QmZ5YMZQfiLhjiXoPQBxJyY1KPVPzhUXDbD1B7bYQCVKjQ"
+      ]
     }
   ],
   "releases": {
+    "0.8.24": "solc-linux-amd64-v0.8.24+commit.e11b9ed9",
     "0.8.23": "solc-linux-amd64-v0.8.23+commit.f704f362",
     "0.8.22": "solc-linux-amd64-v0.8.22+commit.4fc1097e",
     "0.8.21": "solc-linux-amd64-v0.8.21+commit.d9974bed",
@@ -1030,5 +1043,5 @@
     "0.4.11": "solc-linux-amd64-v0.4.11+commit.68ef5810",
     "0.4.10": "solc-linux-amd64-v0.4.10+commit.9e8cc01b"
   },
-  "latestRelease": "0.8.23"
+  "latestRelease": "0.8.24"
 }

--- a/list-macosx-amd64.json
+++ b/list-macosx-amd64.json
@@ -1079,9 +1079,22 @@
         "bzzr://00319ed318e2cd094791d858f56cd7031f60023b00cdd2f9bd2f0d96e5ad918d",
         "dweb:/ipfs/QmXuBDhncvou72S86KxNxeTcVH1pGhU6DCZYzbcVrbfY1p"
       ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.24+commit.e11b9ed9",
+      "version": "0.8.24",
+      "build": "commit.e11b9ed9",
+      "longVersion": "0.8.24+commit.e11b9ed9",
+      "keccak256": "0xf8c5313dfe054e7f3c208905ee6bb4097a1c7a1dd360050f90fab4b182ac1c24",
+      "sha256": "0xcc2d44c706905ccc382f484625dff61d741e0c24232d226f139a6835fc644f3f",
+      "urls": [
+        "bzzr://fab9be6f2b588ade1d1805e2bc52896f9a51d283fa513daf8a70b3e6050524cc",
+        "dweb:/ipfs/QmfNsBiCB9QDHh9fX8QRAJfFKubX2ahutAXnoWx4BfXosT"
+      ]
     }
   ],
   "releases": {
+    "0.8.24": "solc-macosx-amd64-v0.8.24+commit.e11b9ed9",
     "0.8.23": "solc-macosx-amd64-v0.8.23+commit.f704f362",
     "0.8.22": "solc-macosx-amd64-v0.8.22+commit.4fc1097e",
     "0.8.21": "solc-macosx-amd64-v0.8.21+commit.d9974bed",
@@ -1173,5 +1186,5 @@
     "0.4.0": "solc-macosx-amd64-v0.4.0+commit.acd334c9",
     "0.3.6": "solc-macosx-amd64-v0.3.6+commit.988fe5e5"
   },
-  "latestRelease": "0.8.23"
+  "latestRelease": "0.8.24"
 }


### PR DESCRIPTION
I updated this to the latest solc binary release. 

You should know that there is an existing pkg that does this, see: https://github.com/hellwolf/solc.nix

Also, there are now universal macos binaries, so not sure how you want to handle that as macos-amd4 isn't per se accurate. 