### PR TITLE
fix: warning: 'system' has been renamed ...

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
         })
     // {
       overlays.default = final: prev: {
-        solc-bin = self.packages.${prev.system};
+        solc-bin = self.packages.${prev.stdenv.hostPlatform.system};
       };
       templates = {
         default = {

--- a/list-linux-amd64.json
+++ b/list-linux-amd64.json
@@ -945,6 +945,18 @@
       "urls": [
         "dweb:/ipfs/QmPsmKxpd5berCgcTBXXPBC4PLHrb56tr3f6ZMxPGEf6vn"
       ]
+    },
+    {
+      "path": "solc-linux-amd64-v0.8.31-pre.1+commit.b59566f6",
+      "version": "0.8.31",
+      "prerelease": "pre.1",
+      "build": "commit.b59566f6",
+      "longVersion": "0.8.31-pre.1+commit.b59566f6",
+      "keccak256": "0x9829d630def4c4f5b16bbaa305614dfc1cefff697677d8c68ec84162c73ea95c",
+      "sha256": "0xc7ce590c02928ef04ba936b4962eed2162d4eefac5d73288257e16d20512f89f",
+      "urls": [
+        "dweb:/ipfs/QmenGcYX7mEtJA5m6yuDmKsxv2xVe4MqGC5vV8swRZrBtn"
+      ]
     }
   ],
   "releases": {

--- a/list-macosx-amd64.json
+++ b/list-macosx-amd64.json
@@ -1066,6 +1066,18 @@
       "urls": [
         "dweb:/ipfs/QmbrZ9EQQakmwZ2MKzdT6Xp6RQfwbbc6bhrP7ZSeMGE6fx"
       ]
+    },
+    {
+      "path": "solc-macosx-amd64-v0.8.31-pre.1+commit.b59566f6",
+      "version": "0.8.31",
+      "prerelease": "pre.1",
+      "build": "commit.b59566f6",
+      "longVersion": "0.8.31-pre.1+commit.b59566f6",
+      "keccak256": "0x4544c2e6fea0b05f4c51a89b169ae793ee93655d971e424e64651992cb53d878",
+      "sha256": "0x7aa507bd5246bd31576998f6ec45b02313bdb3297722fc8c376141cd46975063",
+      "urls": [
+        "dweb:/ipfs/QmRAbx6MvALUpZUsdw6dizUKfUDiW3mDQb8uCigBgk6W7h"
+      ]
     }
   ],
   "releases": {


### PR DESCRIPTION
fix `evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`

- Also update solc sources, while we're at it.

